### PR TITLE
Add some extra hooks for cleanup and version

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,6 +16,8 @@ const cli = meow(`
 	  --skip-cleanup  Skips cleanup of node_modules
 	  --yolo          Skips cleanup and testing
 	  --tag           Publish under a given dist-tag
+	  --cleanup-task  Name of the custom npm run script to perform cleanup
+	  --version-task  Name of the custom npm run script to perform version bumping
 
 	Examples
 	  $ np patch

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ $ np --help
     --skip-cleanup  Skips cleanup of node_modules
     --yolo          Skips cleanup and testing
     --tag           Publish under a given dist-tag
+    --cleanup-task  Name of the custom npm run script to perform cleanup
+    --version-task  Name of the custom npm run script to perform version bumping
 
   Examples
     $ np patch


### PR DESCRIPTION
![extra hooks](https://media.giphy.com/media/26BRMJBqKOY7X81a0/giphy.gif)
### cleanup-task

The default cleanup behaviour only removes `node_modules` and there wasn't really a suitable npm script to utilise here to add extra behaviour. You can now specify a custom npm run script to execute via the `--cleanup-task` flag.
### version-task

The functionality that can be done in `preversion`, `version` and `postversion` scripts is currently very limited 
